### PR TITLE
Fix incorrect closing tag

### DIFF
--- a/docs/msbuild/zipdirectory-task.md
+++ b/docs/msbuild/zipdirectory-task.md
@@ -58,8 +58,7 @@ Cria um arquivo *.zip* do conteúdo de um diretório.
     <Target Name="ZipOutputPath" AfterTargets="Build">
         <ZipDirectory
             SourceDirectory="$(OutputPath)"
-            DestinationFile="$(MSBuildProjectDirectory)\output.zip">
-        />
+            DestinationFile="$(MSBuildProjectDirectory)\output.zip" />
     </Target>
 
 </Project>


### PR DESCRIPTION
Remove duplicate closing of ZipDirectory element in example code

It relates to the issue MicrosoftDocs/visualstudio-docs#1776

See MicrosoftDocs/visualstudio-docs#1786 for the English change.