### PR TITLE
Include a blank space

### DIFF
--- a/docs/extensibility/extensibility-hello-world.md
+++ b/docs/extensibility/extensibility-hello-world.md
@@ -72,7 +72,7 @@ Agora você deve ver o projeto HelloWorld no **Solution Explorer**.
 
 Etapa 1. Se você selecionar o arquivo *manifesto .vsixmanifest,* poderá ver quais opções podem ser mutáveis, como descrição, autor e versão.
 
-Etapa 2. Clique com o botão direito do mouse no projeto (não na solução). No menu de contexto, **selecione Adicionar**e, em seguida, **Novo Item**.
+Etapa 2. Clique com o botão direito do mouse no projeto (não na solução). No menu de contexto, **selecione Adicionar** e, em seguida, **Novo Item**.
 
 Etapa 3. Selecione a seção **Extensibility** e escolha **Comando**.
 


### PR DESCRIPTION
Between "selecione Adicionar" and "e, em seguida, Novo Item" is necessary to include a blank space to promote cohesion and do not display "Adicionare" instead of "Adicionar e".

So, the doc currently displays this description:
"Etapa 2. Clique com o botão direito do mouse no projeto (não na solução). No menu de contexto, selecione **Adicionare**, em seguida, Novo Item."

After this PR the doc will display this description:
"Etapa 2. Clique com o botão direito do mouse no projeto (não na solução). No menu de contexto, selecione **Adicionar e**, em seguida, Novo Item."